### PR TITLE
Correctly sort Very Low level

### DIFF
--- a/post.sh
+++ b/post.sh
@@ -47,7 +47,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Custom order for the activity level labels
-order='["No Data", "Minimal", "Low", "Moderate", "High", "Very High"]'
+order='["No Data", "Minimal", "Very Low", "Low", "Moderate", "High", "Very High"]'
 
 # Extract useful data from the JSON, grouping the data by activity level, listing the states for
 # each


### PR DESCRIPTION
Since [Feb. 22](https://mastodon.social/@covid_wastewater/114049548454176940), the JSON category for the lowest level has been renamed from Minimal to Very Low, and the Very Low's have appeared out of order.

This reorders it correctly.

I left in Minimal just in case the earlier data needs reprocessing or they change the label back.